### PR TITLE
update ports order in docker expose port command (#90)

### DIFF
--- a/course-zoomcamp/05-deployment/06-docker.md
+++ b/course-zoomcamp/05-deployment/06-docker.md
@@ -41,7 +41,7 @@ To get started with Docker for the churn prediction project you can follow the i
       docker run -it -p 9696:9696 churn-prediction:latest
      ```
      Here we use the option _-it_ in order to the Docker run from terminal and shows the result. 
-     The _-p_ parameter is used to map the 9696 port of the Docker to 9696 port of our machine.(first 9696 is the Docker container port and the last is port number of our  machine)
+     The _-p_ parameter is used to map the 9696 port of the Docker to 9696 port of our machine.(first 9696 is the port number of our machine and the last one is Docker container port.)
    - At last you've deployed your prediction app inside a Docker continer. Congratulations 🥳
 
 


### PR DESCRIPTION
I read the docs of docker and see that the first number is the port of the host and the second one is for the container.
here is the docs for reference.
https://docs.docker.com/engine/reference/commandline/run/#publish-or-expose-port--p---expose